### PR TITLE
Rename a lot of URLs to reflect the new name

### DIFF
--- a/404.html
+++ b/404.html
@@ -34,7 +34,7 @@ permalink: 404.html
             </p>
             <p>
               Please report any broken links on the
-              <a href="https://github.com/minetest/minetest.github.io/issues">
+              <a href="https://github.com/luanti-org/luanti-org.github.io/issues">
                 issues page for this website</a>.
             </p>
           </div>

--- a/404.html
+++ b/404.html
@@ -12,7 +12,7 @@ permalink: 404.html
   if (urlParams.has('id')) {
     // Convert to a number for security (only numeric values make sense anyway)
     const topicId = Number(urlParams.get('id'));
-    window.location.replace(`https://forum.minetest.net/viewtopic.php?id=${topicId}`);
+    window.location.replace(`https://forum.luanti.org/viewtopic.php?id=${topicId}`);
   }
 </script>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Luanti Website](https://www.luanti.org)
 
-[![Build status](https://github.com/minetest/minetest.github.io/workflows/build/badge.svg)](https://github.com/minetest/minetest.github.io/actions)\
+[![Build status](https://github.com/luanti-org/luanti-org.github.io/workflows/build/badge.svg)](https://github.com/luanti-org/luanti-org.github.io/actions)\
 The official Luanti website, living at [www.luanti.org](https://www.luanti.org).
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# [Luanti Website](https://www.minetest.net)
+# [Luanti Website](https://www.luanti.org)
 
 [![Build status](https://github.com/minetest/minetest.github.io/workflows/build/badge.svg)](https://github.com/minetest/minetest.github.io/actions)\
-The official Luanti website, living at [www.minetest.net](https://www.minetest.net).
+The official Luanti website, living at [www.luanti.org](https://www.luanti.org).
 
 ## Features
 

--- a/_data/community.yml
+++ b/_data/community.yml
@@ -1,13 +1,13 @@
 - name: Wiki
-  url: https://wiki.minetest.net
+  url: https://wiki.luanti.org
   icon: wiki.svg
 
 - name: Forum
-  url: https://forum.minetest.net
+  url: https://forum.luanti.org
   icon: forum.svg
 
 - name: IRC
-  url: https://wiki.minetest.net/IRC
+  url: https://wiki.luanti.org/IRC
   icon: irc.svg
 
 - name: Servers

--- a/_data/credits.json
+++ b/_data/credits.json
@@ -1,5 +1,5 @@
 {
-	"#": "https://github.com/orgs/minetest/teams/engine/members",
+	"#": "https://github.com/orgs/luanti-org/teams/engine/members",
 	"core_developers": [
 		"Perttu Ahola (celeron55) <celeron55@gmail.com> [Project founder]",
 		"sfan5 <sfan5@live.de>",
@@ -38,7 +38,7 @@
 		"Hugues Ross <hugues.ross@gmail.com>",
 		"Dmitry Kostenko (x2048) <codeforsmile@gmail.com>"
 	],
-	"#": "Currently only https://github.com/orgs/minetest/teams/triagers/members",
+	"#": "Currently only https://github.com/orgs/luanti-org/teams/triagers/members",
 	"core_team": [
 		"Zughy [Issue triager]",
 		"wsor [Issue triager]",

--- a/_data/edu.yml
+++ b/_data/edu.yml
@@ -7,7 +7,7 @@ why:
 
 - title: Modular & Customizable
   para: >-
-    Access [a library of 2000+ free and open source community developed mods](https://content.minetest.net/)
+    Access [a library of 2000+ free and open source community developed mods](https://content.luanti.org/)
     to customize your EDU environment, and an accessible scripting system for
     you and your students to
     [create your own](https://rubenwardy.com/minetest_modding_book/)!
@@ -148,7 +148,7 @@ resources:
   para: >-
     A trove of information, in multiple languages, with a space dedicated to
     education. Looking for more contributions!
-  url: https://wiki.minetest.net/MinetestEDU
+  url: https://wiki.luanti.org/MinetestEDU
 
 - title: ContentDB
   author: Luanti community
@@ -157,7 +157,7 @@ resources:
     A database where modders can submit their mods, games, and texture packs to
     make them easily accessible. Includes features such as a tag system,
     reviews, and more.
-  url:  https://content.minetest.net/packages/?tag=education
+  url:  https://content.luanti.org/packages/?tag=education
 
 - title: BLOCKALOT Server Hosting
   author: Landesmedienzentrum Baden-Württemberg (LMZ)
@@ -180,7 +180,7 @@ resources:
   author: Luanti community
   tag: To host a server by yourself
   para: The basics to host your multiplayer world locally or online.
-  url: https://wiki.minetest.net/Setting_up_a_server
+  url: https://wiki.luanti.org/Setting_up_a_server
 
 - title: Luanti Modding Book
   author: rubenwardy

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -57,5 +57,5 @@ developers:
     - title: Open Source
       description: >
         The engine is open source and transparently developed.
-        [Submit an issue](https://github.com/minetest/minetest/issues)
+        [Submit an issue](https://github.com/luanti-org/luanti/issues)
         for anything you're missing, or get the source code and dig into it yourself.

--- a/_data/features.yml
+++ b/_data/features.yml
@@ -5,7 +5,7 @@ players:
       description: >
         There are many games to choose from. You could survive in a harsh
         environment, build creatively, or fight other players.
-        Just [download a game](https://content.minetest.net/packages/?type=game)
+        Just [download a game](https://content.luanti.org/packages/?type=game)
         or connect to a server.
 
     - title: Enormous Maps
@@ -21,7 +21,7 @@ players:
     - title: Texture Packs
       description: >
         Not happy with the look of the textures?
-        [Change them!](https://content.minetest.net/packages/?type=txp)
+        [Change them!](https://content.luanti.org/packages/?type=txp)
 
     - title: Beautiful Map Generators
       description: >
@@ -34,20 +34,20 @@ developers:
     - title: Make a Game
       description: >
         Create your own voxel game using our
-        [Lua API](https://dev.minetest.net/Modding_Intro).
+        [Lua API](https://dev.luanti.org/Modding_Intro).
         No need to worry about tricky voxel rendering or networking;
         instead, write scripts to add items and control game play.
 
     - title: Modding API
       description: >
         Use the same Lua API to make mods for any Luanti-based game.
-        Publish your mods on [ContentDB](https://content.minetest.net),
+        Publish your mods on [ContentDB](https://content.luanti.org),
         and contribute to others' mods.
 
     - title: Large Collection of Existing Mods
       description: >
         There are over 1100 open source mods on
-        [ContentDB](https://content.minetest.net/),
+        [ContentDB](https://content.luanti.org/),
         which are ready to be used, adapted or learned from.
 
     - title: Friendly Community

--- a/_data/gallery.yml
+++ b/_data/gallery.yml
@@ -1,23 +1,23 @@
 - image: /media/gallery/1.jpg
-  title: "[Backrooms Test](https://content.minetest.net/packages/Sumianvoice/backroomtest/), a game about liminal spaces"
+  title: "[Backrooms Test](https://content.luanti.org/packages/Sumianvoice/backroomtest/), a game about liminal spaces"
 
 - image: /media/gallery/2.jpg
-  title: "[Soothing 32](https://content.minetest.net/packages/Zughy/soothing32/) texture pack"
+  title: "[Soothing 32](https://content.luanti.org/packages/Zughy/soothing32/) texture pack"
 
 - image: /media/gallery/3.jpg
-  title: "Customized inventory screen from the [i3](https://content.minetest.net/packages/jp/i3/) mod"
+  title: "Customized inventory screen from the [i3](https://content.luanti.org/packages/jp/i3/) mod"
 
 - image: /media/gallery/4.jpg
-  title: "[Glitch](https://content.minetest.net/packages/Wuzzy/glitch/), a platformer puzzle game with a story"
+  title: "[Glitch](https://content.luanti.org/packages/Wuzzy/glitch/), a platformer puzzle game with a story"
 
 - image: /media/gallery/5.jpg
-  title: "[Steampunk Blimp](https://content.minetest.net/packages/apercy/steampunk_blimp/) mod for Minetest Game"
+  title: "[Steampunk Blimp](https://content.luanti.org/packages/apercy/steampunk_blimp/) mod for Minetest Game"
 
 - image: /media/gallery/6.jpg
-  title: "[Animalia](https://content.minetest.net/packages/ElCeejo/animalia/) mod"
+  title: "[Animalia](https://content.luanti.org/packages/ElCeejo/animalia/) mod"
 
 - image: /media/gallery/7.jpg
-  title: "[RPG16](https://content.minetest.net/packages/Hugues%20Ross/rpg16/) texture pack"
+  title: "[RPG16](https://content.luanti.org/packages/Hugues%20Ross/rpg16/) texture pack"
 
 - image: /media/gallery/8.jpg
-  title: "[Minetest Game](https://content.minetest.net/packages/Minetest/minetest_game/), the game where everything began"
+  title: "[Minetest Game](https://content.luanti.org/packages/Minetest/minetest_game/), the game where everything began"

--- a/_data/release.yml
+++ b/_data/release.yml
@@ -3,4 +3,4 @@ latest:
   version_code: 5010000
   date: "2024-11-10"
   protocol_version: 46
-  url: "https://www.minetest.net/downloads/"
+  url: "https://www.luanti.org/downloads/"

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -3,7 +3,7 @@
   icon: matrix.png
 
 - name: Mastodon
-  url: https://fosstodon.org/@minetest
+  url: https://fosstodon.org/@Luanti
   icon: mastodon.png
 
 - name: Discord

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
         <h5 class="footer-title">Luanti</h5>
         <ul class="list-unstyled">
           <li><a href="{{ '/downloads/' | relative_url }}">Downloads</a></li>
-          <li><a href="https://blog.minetest.net/">News</a></li>
+          <li><a href="https://blog.luanti.org/">News</a></li>
           <li><a href="{{ '/credits/' | relative_url }}">Credits</a></li>
           <li><a href="{{ '/education/' | relative_url }}">For Education</a></li>
           <li><a href="/app-privacy-policy/">Privacy Policy</a></li>
@@ -17,20 +17,20 @@
       <div class="column is-6-mobile">
         <h5 class="footer-title">Content</h5>
         <ul class="list-unstyled">
-          <li><a href="https://content.minetest.net">ContentDB</a></li>
-          <li><a href="https://content.minetest.net/packages/?type=game">Games</a></li>
-          <li><a href="https://content.minetest.net/packages/?type=mod">Mods</a></li>
-          <li><a href="https://content.minetest.net/packages/?type=txp">Texture Packs</a></li>
+          <li><a href="https://content.luanti.org">ContentDB</a></li>
+          <li><a href="https://content.luanti.org/packages/?type=game">Games</a></li>
+          <li><a href="https://content.luanti.org/packages/?type=mod">Mods</a></li>
+          <li><a href="https://content.luanti.org/packages/?type=txp">Texture Packs</a></li>
         </ul>
       </div>
 
       <div class="column is-6-mobile">
         <h5 class="footer-title">Community</h5>
         <ul class="list-unstyled">
-          <li><a href="https://forum.minetest.net">Forums</a></li>
-          <li><a href="https://wiki.minetest.net/IRC">IRC</a></li>
+          <li><a href="https://forum.luanti.org">Forums</a></li>
+          <li><a href="https://wiki.luanti.org/IRC">IRC</a></li>
           <li><a href="{{ '/servers/' | relative_url }}">Servers</a></li>
-          <li><a href="https://wiki.minetest.net">Player Wiki</a></li>
+          <li><a href="https://wiki.luanti.org">Player Wiki</a></li>
         </ul>
       </div>
 
@@ -48,9 +48,9 @@
         <h5 class="footer-title">Development</h5>
         <ul class="list-unstyled">
           <li><a href="https://github.com/minetest/minetest">GitHub</a></li>
-          <li><a href="https://wiki.minetest.net/IRC">#minetest-dev on Libera IRC</a></li>
-          <li><a href="https://dev.minetest.net/Main_Page">Developer Wiki</a></li>
-          <li><a href="https://api.minetest.net">Lua API reference</a></li>
+          <li><a href="https://wiki.luanti.org/IRC">#minetest-dev on Libera IRC</a></li>
+          <li><a href="https://dev.luanti.org/Main_Page">Developer Wiki</a></li>
+          <li><a href="https://api.luanti.org">Lua API reference</a></li>
           <li><a href="{{ '/get-involved/#donate' | relative_url }}">Donate</a></li>
           <li><a href="https://rubenwardy.com/minetest_modding_book/">Luanti Modding Book</a></li>
         </ul>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -47,7 +47,7 @@
       <div class="column is-6-mobile">
         <h5 class="footer-title">Development</h5>
         <ul class="list-unstyled">
-          <li><a href="https://github.com/minetest/minetest">GitHub</a></li>
+          <li><a href="https://github.com/luanti-org/luanti">GitHub</a></li>
           <li><a href="https://wiki.luanti.org/IRC">#minetest-dev on Libera IRC</a></li>
           <li><a href="https://dev.luanti.org/Main_Page">Developer Wiki</a></li>
           <li><a href="https://api.luanti.org">Lua API reference</a></li>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -61,9 +61,9 @@
 
   <div class="footer-copyright">
     © 2015-{{ site.time | date: '%Y' }} The Luanti Team.
-    <a href="https://github.com/minetest/minetest.github.io">Source</a><br />
+    <a href="https://github.com/luanti-org/luanti-org.github.io">Source</a><br />
     MIT for code, CC-BY-SA 3.0 for content, media under
-    <a href="https://github.com/minetest/minetest.github.io/#license">various licenses</a>.
+    <a href="https://github.com/luanti-org/luanti-org.github.io/#license">various licenses</a>.
     Font Awesome icons under <a href="https://fontawesome.com/license">CC-BY 4.0</a>.
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -38,7 +38,7 @@
         <h5 class="footer-title">Social</h5>
         <ul class="list-unstyled">
           <li><a href="https://matrix.to/#/#minetest:tchncs.de">Matrix</a></li>
-          <li><a href="https://fosstodon.org/@Minetest" rel="me">Mastodon</a></li>
+          <li><a href="https://fosstodon.org/@Luanti" rel="me">Mastodon</a></li>
           <li><a href="https://discord.gg/minetest">Discord</a></li>
           <li><a href="https://reddit.com/r/minetest/">Subreddit</a></li>
         </ul>
@@ -48,7 +48,7 @@
         <h5 class="footer-title">Development</h5>
         <ul class="list-unstyled">
           <li><a href="https://github.com/luanti-org/luanti">GitHub</a></li>
-          <li><a href="https://wiki.luanti.org/IRC">#minetest-dev on Libera IRC</a></li>
+          <li><a href="https://wiki.luanti.org/IRC">#luanti-dev on Libera IRC</a></li>
           <li><a href="https://dev.luanti.org/Main_Page">Developer Wiki</a></li>
           <li><a href="https://api.luanti.org">Lua API reference</a></li>
           <li><a href="{{ '/get-involved/#donate' | relative_url }}">Donate</a></li>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,8 +4,8 @@
     {{ page.title }}
     {% unless page.title_append == false %}- Luanti {% endunless %}
 </title>
-<link rel="canonical" href="https://www.minetest.net{{ page.url }}">
-<meta name="og:url" content="https://www.minetest.net{{ page.url }}">
+<link rel="canonical" href="https://www.luanti.org{{ page.url }}">
+<meta name="og:url" content="https://www.luanti.org{{ page.url }}">
 <meta name="og:title" content="{{ page.title | escape }}">
 <meta name="og:site_name" content="Luanti">
 {% if page.description %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,8 +24,8 @@
         <a class="navbar-item" href="{{ '/#features' | relative_url }}">Features</a>
         <a class="navbar-item" href="{{ '/#gallery' | relative_url }}">Gallery</a>
         <a class="navbar-item" href="{{ '/downloads/' | relative_url }}">Download</a>
-        <a class="navbar-item" href="https://content.minetest.net">ContentDB</a>
-        <a class="navbar-item" href="https://blog.minetest.net/">Blog</a>
+        <a class="navbar-item" href="https://content.luanti.org">ContentDB</a>
+        <a class="navbar-item" href="https://blog.luanti.org/">Blog</a>
         <a class="navbar-item" href="{{ '/get-involved/' | relative_url }}">Get Involved</a>
         <a class="navbar-item" href="{{ '/education/' | relative_url }}">Education</a>
       </div>

--- a/app-privacy-policy.md
+++ b/app-privacy-policy.md
@@ -15,7 +15,7 @@ layout: page_subtitle
 
 Luanti may connect to the following services during its operation:
 
-* The main website (www.minetest.net): used to get the most recent version
+* The main website (www.luanti.org): used to get the most recent version
 * The server list: used to load the server list in "Play Online"
 * ContentDB: used to install/update content in the main menu
 * Game servers: third-party servers when playing online
@@ -79,11 +79,11 @@ The server list is currently located in the Netherlands.
 ## ContentDB
 
 You can find more information on
-[ContentDB's privacy policy](https://content.minetest.net/privacy_policy/).
+[ContentDB's privacy policy](https://content.luanti.org/privacy_policy/).
 
 ### Information collected
 
-Requests to [ContentDB](https://content.minetest.net) will be made in the main
+Requests to [ContentDB](https://content.luanti.org) will be made in the main
 menu when using the ContentDB feature. This includes checking for updates when
 you have packages from ContentDB installed. The following information will be
 transferred or included:
@@ -96,7 +96,7 @@ transferred or included:
 for example:
 
 ```
-11.22.33.44 content.minetest.net - [06/July/2024:10:05:00 +0200] "GET /packages/Wuzzy/glitch/releases/18414/download/?reason=new HTTP/2.0" 302 233 "-" "Luanti/5.8.0 (Windows/10.0.19041 x86_64)"
+11.22.33.44 content.luanti.org - [06/July/2024:10:05:00 +0200] "GET /packages/Wuzzy/glitch/releases/18414/download/?reason=new HTTP/2.0" 302 233 "-" "Luanti/5.8.0 (Windows/10.0.19041 x86_64)"
 ```
 
 ### How it is used
@@ -132,14 +132,14 @@ data to be moved within the United Kingdom and/or EU.
 
 ### Removal requests
 
-See [ContentDB's privacy policy](https://content.minetest.net/privacy_policy/#removal-requests).
+See [ContentDB's privacy policy](https://content.luanti.org/privacy_policy/#removal-requests).
 
 
 ## Version checking
 
 ### Information collected
 
-When you open Luanti, it may contact www.minetest.net to fetch information
+When you open Luanti, it may contact www.luanti.org to fetch information
 about the most recent version. The following information will be transferred or
 included:
 

--- a/app-privacy-policy.md
+++ b/app-privacy-policy.md
@@ -3,7 +3,7 @@ title: Luanti Privacy Policy
 description: Privacy policy for the Luanti application.
 small: |
   Last updated: 2024-08-17
-  (<a href="https://github.com/minetest/minetest.github.io/commits/master/app-privacy-policy.md">View updates</a>)
+  (<a href="https://github.com/luanti-org/luanti-org.github.io/commits/master/app-privacy-policy.md">View updates</a>)
 layout: page_subtitle
 ---
 

--- a/credits.html
+++ b/credits.html
@@ -39,8 +39,8 @@ redirect_from:
         <h2>Contributors</h2>
         <p>
           Also see the complete lists of
-          <a href="https://github.com/minetest/minetest/graphs/contributors">Luanti</a> and
-          <a href="https://github.com/minetest/minetest_game/graphs/contributors">Minetest Game</a>
+          <a href="https://github.com/luanti-org/luanti/graphs/contributors">Luanti</a> and
+          <a href="https://github.com/luanti-org/minetest_game/graphs/contributors">Minetest Game</a>
           contributors.
         </p>
 

--- a/credits.html
+++ b/credits.html
@@ -23,7 +23,7 @@ redirect_from:
           Core developers decide what can be added to Luanti by voting for
           and against pull requests. They also have commit access to the Luanti
           team's repositories on GitHub.
-          <a href="https://dev.minetest.net/Organisation">Learn more.</a>
+          <a href="https://dev.luanti.org/Organisation">Learn more.</a>
         </p>
 
         <h3>Active Core Developers</h3>

--- a/customize.html
+++ b/customize.html
@@ -1,4 +1,4 @@
 ---
 title: Customize
-redirect_to: https://content.minetest.net
+redirect_to: https://content.luanti.org
 ---

--- a/downloads.html
+++ b/downloads.html
@@ -42,12 +42,12 @@ redirect_from:
         </p>
         <ul>
           <li class="has-text-weight-bold">
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-win64.zip">
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-win64.zip">
               Luanti 5.10.0 - portable, 64-bit (recommended)
             </a>
           </li>
           <li>
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-win32.zip">
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-win32.zip">
               Luanti 5.10.0 - portable, 32-bit
             </a>
           </li>
@@ -80,13 +80,13 @@ redirect_from:
         <ul>
           <li>
             ARM (for most devices):
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-arm64-v8a.apk">64-bit</a> -
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-armeabi-v7a.apk">32-bit</a>
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-arm64-v8a.apk">64-bit</a> -
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-armeabi-v7a.apk">32-bit</a>
           </li>
           <li>
             x86:
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-x86_64.apk">64-bit</a> -
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-x86.apk">32-bit</a>
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-x86_64.apk">64-bit</a> -
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-x86.apk">32-bit</a>
           </li>
         </ul>
         <p>
@@ -155,13 +155,13 @@ make install
         <ul>
           <li class="has-text-weight-bold">
             Signed Apple Silicon -
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-macos11.3_arm64.zip">
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-macos11.3_arm64.zip">
               Luanti 5.10.0 - App
             </a>
           </li>
           <li class="has-text-weight-bold">
             Signed Intel 64-bit -
-            <a href="https://github.com/minetest/minetest/releases/download/5.10.0/luanti-5.10.0-macos11.3_x86_64.zip">
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-macos11.3_x86_64.zip">
               Luanti 5.10.0 - App
             </a>
           </li>
@@ -179,12 +179,12 @@ make install
       <div class="column is-12-tablet is-6-desktop">
         <h2>Source code</h2>
         <p>
-          Get the latest <a href="https://github.com/minetest/minetest/tree/stable-5">stable</a>
-          or <a href="https://github.com/minetest/minetest">development</a> source code from
+          Get the latest <a href="https://github.com/luanti-org/luanti/tree/stable-5">stable</a>
+          or <a href="https://github.com/luanti-org/luanti">development</a> source code from
           <a href="https://github.com/minetest">GitHub</a>.
         </p>
         <p>
-          See the <a href="https://github.com/minetest/minetest/blob/master/README.md">README</a>
+          See the <a href="https://github.com/luanti-org/luanti/blob/master/README.md">README</a>
           for details on how to compile Luanti from source.
         </p>
       </div>
@@ -192,7 +192,7 @@ make install
     <div>
       <hr>
       <p>
-        Looking for older versions? Check out the <a href="https://github.com/minetest/minetest/releases">list of releases</a> on GitHub!
+        Looking for older versions? Check out the <a href="https://github.com/luanti-org/luanti/releases">list of releases</a> on GitHub!
       </p>
     </div>
   </div>

--- a/downloads.html
+++ b/downloads.html
@@ -18,17 +18,17 @@ redirect_from:
     <h2>Getting started</h2>
     <p>
       Are you a new user?
-      Have a look at our <a href="https://wiki.minetest.net/Getting_Started">Getting Started</a>,
-      <a href="https://wiki.minetest.net/FAQ">FAQ</a>,
-       and <a href="https://wiki.minetest.net/Tutorials">Tutorials</a> pages on our wiki.<br>
-      Otherwise, feel free to look at the <a href="https://dev.minetest.net/Changelog#5.9.1_.E2.86.92_5.10.0">changelog</a>.
+      Have a look at our <a href="https://wiki.luanti.org/Getting_Started">Getting Started</a>,
+      <a href="https://wiki.luanti.org/FAQ">FAQ</a>,
+       and <a href="https://wiki.luanti.org/Tutorials">Tutorials</a> pages on our wiki.<br>
+      Otherwise, feel free to look at the <a href="https://dev.luanti.org/Changelog#5.9.1_.E2.86.92_5.10.0">changelog</a>.
     </p>
     <p>
       You may also want to look at some
-      <a href="https://content.minetest.net/packages/?type=game">games</a>.
+      <a href="https://content.luanti.org/packages/?type=game">games</a>.
       Games provide basic game play for the engine to run using Lua scripts.
       Different games have different objectives, such as survival, building or Player vs Player.
-      You can then add <a href="https://content.minetest.net/packages/?type=mod">mods</a> on
+      You can then add <a href="https://content.luanti.org/packages/?type=mod">mods</a> on
       top of a game in order to customize your experience further.
     </p>
 
@@ -54,11 +54,11 @@ redirect_from:
         </ul>
         <p>
           Stuck? See
-          <a href="https://wiki.minetest.net/Getting_Started#Windows">help on getting Luanti on Windows.</a>
+          <a href="https://wiki.luanti.org/Getting_Started#Windows">help on getting Luanti on Windows.</a>
         </p>
         <p>
           You can also get the latest development version of Luanti from
-          <a href="https://forum.minetest.net/viewforum.php?f=42">builds made by community members</a>.
+          <a href="https://forum.luanti.org/viewforum.php?f=42">builds made by community members</a>.
           These builds are more recent than the officially released builds
           and contain new features (at the cost of stability).
         </p>

--- a/downloads.html
+++ b/downloads.html
@@ -181,7 +181,7 @@ make install
         <p>
           Get the latest <a href="https://github.com/luanti-org/luanti/tree/stable-5">stable</a>
           or <a href="https://github.com/luanti-org/luanti">development</a> source code from
-          <a href="https://github.com/minetest">GitHub</a>.
+          <a href="https://github.com/luanti-org">GitHub</a>.
         </p>
         <p>
           See the <a href="https://github.com/luanti-org/luanti/blob/master/README.md">README</a>

--- a/education.html
+++ b/education.html
@@ -107,7 +107,7 @@ layout: default
     <p>
       Contribute back to the community by writing about your project
       and/or making your learning resources publicly available. Then,
-      <a href="https://github.com/minetest/minetest.github.io/issues/new">
+      <a href="https://github.com/luanti-org/luanti-org.github.io/issues/new">
         create an issue</a> or
       <a href="https://rubenwardy.com/contact/">contact rubenwardy</a>.
     </p>

--- a/get-involved.html
+++ b/get-involved.html
@@ -86,7 +86,7 @@ redirect_from:
               For good first tasks, look out for the "good first issue" label on the
               <a href="https://github.com/minetest/minetest/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22">engine</a>
               or
-              <a href="https://github.com/minetest/minetest.github.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22">website</a>
+              <a href="https://github.com/luanti-org/luanti-org.github.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22">website</a>
               repositories.
             </li>
           </ul>
@@ -267,8 +267,8 @@ redirect_from:
         <tr>
           <td>www.luanti.org</td>
           <td>celeron55</td>
-          <td><a href="https://github.com/minetest/minetest.github.io">Source</a></td>
-          <td><a href="https://github.com/minetest/minetest.github.io/issues">Issues</a></td>
+          <td><a href="https://github.com/luanti-org/luanti-org.github.io">Source</a></td>
+          <td><a href="https://github.com/luanti-org/luanti-org.github.io/issues">Issues</a></td>
         </tr>
         <tr>
           <td>forum.luanti.org</td>
@@ -322,7 +322,7 @@ redirect_from:
       <p>
         Luanti doesn't have a legal body to accept donations, and most core
         developers do not wish to accept donations
-        <a href="https://github.com/minetest/minetest.github.io/issues/222">themselves</a>.
+        <a href="https://github.com/luanti-org/luanti-org.github.io/issues/222">themselves</a>.
       </p>
 
       <h3 class="is-size-3">Luanti <span class="is-size-5 has-text-grey has-text-weight-normal">(team)</span></h3>

--- a/get-involved.html
+++ b/get-involved.html
@@ -76,7 +76,7 @@ redirect_from:
             </li>
             <li>
               Report bugs and submit patches on
-              <a href="https://github.com/minetest">GitHub</a> or <a href="https://wiki.luanti.org/IRC">IRC</a>.
+              <a href="https://github.com/luanti-org">GitHub</a> or <a href="https://wiki.luanti.org/IRC">IRC</a>.
             </li>
             <li>
               Read the <a href="https://dev.luanti.org/Engine">engine</a>
@@ -131,7 +131,7 @@ redirect_from:
       </p>
       <p>
         All development and decisions are made in public, on
-        <a href="https://github.com/minetest">GitHub</a> and
+        <a href="https://github.com/luanti-org">GitHub</a> and
         <a href="https://wiki.luanti.org/IRC">Internet Relay Chat (IRC)</a>.
         Meetings are occasionally held on IRC, with
         <a href="https://dev.luanti.org/Meetings">plans and notes made public</a>.
@@ -152,7 +152,7 @@ redirect_from:
       <p>
         Luanti is distributed as an engine, combined with a couple of games.
         Upstream repositories can be found at
-        <a href="https://github.com/minetest/">https://github.com/minetest/</a>.
+        <a href="https://github.com/luanti-org/">https://github.com/luanti-org/</a>.
       </p>
 
       <ul>
@@ -273,7 +273,7 @@ redirect_from:
         <tr>
           <td>forum.luanti.org</td>
           <td>celeron55</td>
-          <td><a href="https://github.com/minetest/forum.minetest.net_template1">Theme</a></td>
+          <td><a href="https://github.com/luanti-org/forum.luanti.org_template1">Theme</a></td>
           <td>Contact a moderator for concerns about content (Use "report this post" if possible)</td>
         </tr>
         <tr>
@@ -288,14 +288,14 @@ redirect_from:
         <tr>
           <td>servers.luanti.org</td>
           <td>sfan5</td>
-          <td><a href="https://github.com/minetest/serverlist">Source</a></td>
-          <td><a href="https://github.com/minetest/serverlist/issues">Issues</a></td>
+          <td><a href="https://github.com/luanti-org/serverlist">Source</a></td>
+          <td><a href="https://github.com/luanti-org/serverlist/issues">Issues</a></td>
         </tr>
         <tr>
           <td>content.luanti.org</td>
           <td>rubenwardy</td>
-          <td><a href="https://github.com/minetest/contentdb">Source</a></td>
-          <td><a href="https://github.com/minetest/contentdb/issues">Issues</a></td>
+          <td><a href="https://github.com/luanti-org/contentdb">Source</a></td>
+          <td><a href="https://github.com/luanti-org/contentdb/issues">Issues</a></td>
         </tr>
         <tr>
           <td>irc.luanti.org</td>

--- a/get-involved.html
+++ b/get-involved.html
@@ -138,8 +138,8 @@ redirect_from:
       </p>
       <p>
         The core team is best contacted on
-        <a href="https://wiki.luanti.org/IRC">IRC</a> at
-        <code>#minetest-dev @ irc.libera.chat</code>.
+        <a href="https://wiki.luanti.org/IRC">IRC</a> in
+        <code>#luanti-dev @ irc.libera.chat</code>.
       </p>
       <p>
         For more information, take a look at

--- a/get-involved.html
+++ b/get-involved.html
@@ -84,7 +84,7 @@ redirect_from:
             </li>
             <li>
               For good first tasks, look out for the "good first issue" label on the
-              <a href="https://github.com/minetest/minetest/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22">engine</a>
+              <a href="https://github.com/luanti-org/luanti/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22">engine</a>
               or
               <a href="https://github.com/luanti-org/luanti-org.github.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22">website</a>
               repositories.
@@ -185,7 +185,7 @@ redirect_from:
       </p>
       <p>
         <a class="button is-primary"
-            href="https://github.com/minetest/minetest/blob/master/doc/direction.md">
+            href="https://github.com/luanti-org/luanti/blob/master/doc/direction.md">
           Roadmap
         </a>
       </p>
@@ -216,30 +216,30 @@ redirect_from:
           <td>Luanti Engine</td>
           <td>Core developers</td>
           <td>
-            <a href="https://github.com/minetest/minetest">Source</a>
+            <a href="https://github.com/luanti-org/luanti">Source</a>
           </td>
           <td>
-            <a href="https://github.com/minetest/minetest/issues">Issues</a>
+            <a href="https://github.com/luanti-org/luanti/issues">Issues</a>
           </td>
         </tr>
         <tr>
           <td>Minetest Game</td>
           <td>Core developers</td>
           <td>
-            <a href="https://github.com/minetest/minetest_game">Source</a>
+            <a href="https://github.com/luanti-org/minetest_game">Source</a>
           </td>
           <td>
-            <a href="https://github.com/minetest/minetest_game/issues">Issues</a>
+            <a href="https://github.com/luanti-org/minetest_game/issues">Issues</a>
           </td>
         </tr>
         <tr>
           <td>Minetestmapper</td>
           <td>Core developers</td>
           <td>
-            <a href="https://github.com/minetest/minetestmapper">Source</a>
+            <a href="https://github.com/luanti-org/minetestmapper">Source</a>
           </td>
           <td>
-            <a href="https://github.com/minetest/minetestmapper/issues">Issues</a>
+            <a href="https://github.com/luanti-org/minetestmapper/issues">Issues</a>
           </td>
         </tr>
         <tr>

--- a/get-involved.html
+++ b/get-involved.html
@@ -48,18 +48,18 @@ redirect_from:
               <a href="#reporting-issues">Report bugs and request features</a>.
             </li>
             <li>
-              Give support on the <a href="https://forum.minetest.net">forums</a> and <a href="https://wiki.minetest.net/IRC">IRC</a>.
+              Give support on the <a href="https://forum.luanti.org">forums</a> and <a href="https://wiki.luanti.org/IRC">IRC</a>.
             </li>
             <li>
               Help translate Luanti using
               <a href="https://hosted.weblate.org/projects/minetest/minetest/">our web interface</a>.
             </li>
             <li>
-              <a href="https://forum.minetest.net/viewtopic.php?f=7&t=19877">Help us review and merge pull requests</a>.
+              <a href="https://forum.luanti.org/viewtopic.php?f=7&t=19877">Help us review and merge pull requests</a>.
             </li>
             <li>
               <a href="#donate">Donate</a> money to pay for infrastructure, and
-              <a href="https://content.minetest.net/donate/">support your favourite contributors</a>.
+              <a href="https://content.luanti.org/donate/">support your favourite contributors</a>.
             </li>
           </ul>
         </div>
@@ -69,17 +69,17 @@ redirect_from:
         <div class="content">
           <ul>
             <li>
-              Work on a <a href="https://dev.minetest.net/Modding_Intro">game or mod</a>
-              and publish it to <a href="https://content.minetest.net">ContentDB</a>.
+              Work on a <a href="https://dev.luanti.org/Modding_Intro">game or mod</a>
+              and publish it to <a href="https://content.luanti.org">ContentDB</a>.
               The <a href="https://rubenwardy.com/minetest_modding_book/">Luanti Modding Book</a>
               provides an easy introduction to creating mods and games.
             </li>
             <li>
               Report bugs and submit patches on
-              <a href="https://github.com/minetest">GitHub</a> or <a href="https://wiki.minetest.net/IRC">IRC</a>.
+              <a href="https://github.com/minetest">GitHub</a> or <a href="https://wiki.luanti.org/IRC">IRC</a>.
             </li>
             <li>
-              Read the <a href="https://dev.minetest.net/Engine">engine</a>
+              Read the <a href="https://dev.luanti.org/Engine">engine</a>
               documentation.
             </li>
             <li>
@@ -101,11 +101,11 @@ redirect_from:
             </li>
             <li>
               Create a
-              <a href="https://wiki.minetest.net/Texture_Packs">Texture Pack</a>.
+              <a href="https://wiki.luanti.org/Texture_Packs">Texture Pack</a>.
             </li>
             <li>
               Hang around on the forums, and help with
-              <a href="https://forum.minetest.net/viewtopic.php?f=47&t=1585">texture requests</a>.
+              <a href="https://forum.luanti.org/viewtopic.php?f=47&t=1585">texture requests</a>.
             </li>
           </ul>
         </div>
@@ -132,18 +132,18 @@ redirect_from:
       <p>
         All development and decisions are made in public, on
         <a href="https://github.com/minetest">GitHub</a> and
-        <a href="https://wiki.minetest.net/IRC">Internet Relay Chat (IRC)</a>.
+        <a href="https://wiki.luanti.org/IRC">Internet Relay Chat (IRC)</a>.
         Meetings are occasionally held on IRC, with
-        <a href="https://dev.minetest.net/Meetings">plans and notes made public</a>.
+        <a href="https://dev.luanti.org/Meetings">plans and notes made public</a>.
       </p>
       <p>
         The core team is best contacted on
-        <a href="https://wiki.minetest.net/IRC">IRC</a> at
+        <a href="https://wiki.luanti.org/IRC">IRC</a> at
         <code>#minetest-dev @ irc.libera.chat</code>.
       </p>
       <p>
         For more information, take a look at
-        <a href="https://dev.minetest.net/All_rules_regarding_to_development">
+        <a href="https://dev.luanti.org/All_rules_regarding_to_development">
           all the rules regarding to development
         </a>.
       </p>
@@ -165,14 +165,14 @@ redirect_from:
           <strong>Games</strong> define game content: nodes, entities,
           textures, meshes, sounds and custom behavior implemented in Lua.
           Games consist of mods that plug into the engine using the
-          <a href="https://dev.minetest.net/Modding_Intro">Modding API</a>.
+          <a href="https://dev.luanti.org/Modding_Intro">Modding API</a>.
         </li>
       </ul>
 
       <p>
         For more information, see the
-        <a href="https://dev.minetest.net/Terminology">terminology</a> or
-        <a href="https://dev.minetest.net/Engine">engine overview</a>
+        <a href="https://dev.luanti.org/Terminology">terminology</a> or
+        <a href="https://dev.luanti.org/Engine">engine overview</a>
         developer wiki pages.
       </p>
 
@@ -259,46 +259,46 @@ redirect_from:
           <th>Issue Tracker</th>
         </tr>
         <tr>
-          <td>*.minetest.net DNS</td>
+          <td>*.luanti.org DNS</td>
           <td>celeron55</td>
           <td>n/a</td>
-          <td>Contact celeron55. His approval is needed to host under minetest.net</td>
+          <td>Contact celeron55. His approval is needed to host under luanti.org</td>
         </tr>
         <tr>
-          <td>www.minetest.net</td>
+          <td>www.luanti.org</td>
           <td>celeron55</td>
           <td><a href="https://github.com/minetest/minetest.github.io">Source</a></td>
           <td><a href="https://github.com/minetest/minetest.github.io/issues">Issues</a></td>
         </tr>
         <tr>
-          <td>forum.minetest.net</td>
+          <td>forum.luanti.org</td>
           <td>celeron55</td>
           <td><a href="https://github.com/minetest/forum.minetest.net_template1">Theme</a></td>
           <td>Contact a moderator for concerns about content (Use "report this post" if possible)</td>
         </tr>
         <tr>
-          <td>wiki/dev.minetest.net</td>
+          <td>wiki/dev.luanti.org</td>
           <td>celeron55</td>
           <td><a href="https://www.mediawiki.org">MediaWiki</a></td>
           <td>
-            <a href="https://forum.minetest.net/viewtopic.php?f=3&t=10473">Ask for an account to edit</a>
-            or report issues <a href="https://forum.minetest.net/viewforum.php?f=3">on the forum</a>
+            <a href="https://forum.luanti.org/viewtopic.php?f=3&t=10473">Ask for an account to edit</a>
+            or report issues <a href="https://forum.luanti.org/viewforum.php?f=3">on the forum</a>
           </td>
         </tr>
         <tr>
-          <td>servers.minetest.net</td>
+          <td>servers.luanti.org</td>
           <td>sfan5</td>
           <td><a href="https://github.com/minetest/serverlist">Source</a></td>
           <td><a href="https://github.com/minetest/serverlist/issues">Issues</a></td>
         </tr>
         <tr>
-          <td>content.minetest.net</td>
+          <td>content.luanti.org</td>
           <td>rubenwardy</td>
           <td><a href="https://github.com/minetest/contentdb">Source</a></td>
           <td><a href="https://github.com/minetest/contentdb/issues">Issues</a></td>
         </tr>
         <tr>
-          <td>irc.minetest.net</td>
+          <td>irc.luanti.org</td>
           <td>sfan5</td>
           <td><a href="https://github.com/moritz/ilbot">Source</a></td>
           <td>Contact sfan5</td>
@@ -352,7 +352,7 @@ redirect_from:
         check those out.
       </p>
       <p>
-        <a class="button is-primary" href="https://content.minetest.net/donate/">
+        <a class="button is-primary" href="https://content.luanti.org/donate/">
           Find packages to support on ContentDB
         </a>
       </p>

--- a/index.html
+++ b/index.html
@@ -66,9 +66,9 @@ redirect_from:
 <section class="section">
   <div class="container is-max-desktop blog-embed">
     <h2 id="blog" class="title section-title">Blog</h2>
-    <iframe src="https://blog.minetest.net/embed_latest/" title="Latest Luanti Blog Post" frameborder="0"></iframe>
+    <iframe src="https://blog.luanti.org/embed_latest/" title="Latest Luanti Blog Post" frameborder="0"></iframe>
     <p>
-      <a class="button is-primary" href="https://blog.minetest.net/">
+      <a class="button is-primary" href="https://blog.luanti.org/">
         View more blog posts
       </a>
     </p>

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "minetest.net",
+  "name": "luanti.org",
   "icons": [
     {
       "src": "\/media\/favicon\/36x36.png",

--- a/press.html
+++ b/press.html
@@ -20,7 +20,7 @@ layout: default
         <h3 id="logo">Logo</h3>
         <ul>
           <li>
-            <a href="https://raw.githubusercontent.com/minetest/minetest/master/misc/minetest.svg">
+            <a href="https://raw.githubusercontent.com/luanti-org/luanti/master/misc/luanti.svg">
               Color .SVG
             </a>
           </li>

--- a/servers.html
+++ b/servers.html
@@ -8,7 +8,7 @@ redirect_from:
 
 <script defer>
   var master = {
-    root: 'https://servers.minetest.net/',
+    root: 'https://servers.luanti.org/',
     no_avgtop: true,
     no_ping: true,
     no_uptime: true,
@@ -16,7 +16,7 @@ redirect_from:
     clients_min: 1,
   };
 </script>
-<script defer src="https://servers.minetest.net/list.js"></script>
+<script defer src="https://servers.luanti.org/list.js"></script>
 
 <section class="section">
   <div class="container">
@@ -24,7 +24,7 @@ redirect_from:
 
       <h1>Servers</h1>
       <p class="has-text-strong">
-        The server list is also available at <a href="https://servers.minetest.net/" rel="nofollow">servers.minetest.net</a>.
+        The server list is also available at <a href="https://servers.luanti.org/" rel="nofollow">servers.luanti.org</a>.
       </p>
 
       <!-- Loaded by the script at the top of this page -->


### PR DESCRIPTION
Closes #315. This PR:
- Renames all relevant occurrences of minetest.net to luanti.org (except for things like stats.minetest.net which still hasn't moved)
- Renames the Github organisation name in all links as well as relevant repository names (e.g. minetest/minetest -> luanti-org/luanti)
- Also updates the Fosstodon handle which is Luanti now 