### PR TITLE
Update get-involved.html

### DIFF
--- a/get-involved.html
+++ b/get-involved.html
@@ -79,7 +79,7 @@ redirect_from:
               <a href="https://github.com/luanti-org">GitHub</a> or <a href="https://wiki.luanti.org/IRC">IRC</a>.
             </li>
             <li>
-              Read the <a href="https://dev.luanti.org/Engine">engine</a>
+              Read the <a href="https://docs.luanti.org/for-engine-devs/">engine</a>
               documentation.
             </li>
             <li>


### PR DESCRIPTION
updated an old link from https://dev.luanti.org/Engine to https://docs.luanti.org/for-engine-devs/