### PR TITLE
Rename Developer wiki to Luanti Documentation in footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -49,7 +49,7 @@
         <ul class="list-unstyled">
           <li><a href="https://github.com/luanti-org/luanti">GitHub</a></li>
           <li><a href="https://docs.luanti.org/about/irc/">#luanti-dev on Libera IRC</a></li>
-          <li><a href="https://docs.luanti.org/">Developer Wiki</a></li>
+          <li><a href="https://docs.luanti.org/">Luanti Documentation</a></li>
           <li><a href="https://api.luanti.org">Lua API reference</a></li>
           <li><a href="{{ '/get-involved/#donate' | relative_url }}">Donate</a></li>
           <li><a href="https://rubenwardy.com/minetest_modding_book/">Luanti Modding Book</a></li>


### PR DESCRIPTION
There is no point in calling it Developer wiki anymore.