### PR TITLE
[no sq] Three things

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -24,12 +24,11 @@
 }
 
 .home-buttons {
-  margin-top: 2rem;
-  margin-bottom: 1.5rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
 
   .button {
-    margin-left: 1rem;
-    margin-right: 1rem;
+    margin: 0.5rem 1rem;
   }
 }
 

--- a/downloads.html
+++ b/downloads.html
@@ -72,9 +72,7 @@ redirect_from:
       <div class="column is-12-tablet is-6-desktop">
         <h2>Android</h2>
         <p>Android 6 or later is recommended.</p>
-        <a href="https://play.google.com/store/apps/details?id=net.minetest.minetest&utm_source=website&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
-          <img style="max-height: 7em;" alt="Get it on Google Play" src="{{ '/media/google-play-badge.png' | relative_url }}"/>
-        </a>
+        <p>Note: Luanti is temporarily unavailable on Google Play at the moment, please use the other download options until it is restored.</p>
         <a href="https://f-droid.org/packages/net.minetest.minetest">
           <img style="max-height: 7em;" alt="Get it on F-Droid" src="{{ '/media/fdroid-badge.png' | relative_url }}"/>
         </a>

--- a/downloads.html
+++ b/downloads.html
@@ -79,21 +79,21 @@ redirect_from:
           <img style="max-height: 7em;" alt="Get it on F-Droid" src="{{ '/media/fdroid-badge.png' | relative_url }}"/>
         </a>
 
-        <!-- <p>
+        <p>
           Alternatively, download the APK:
         </p>
         <ul>
           <li>
             ARM (for most devices):
-            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-arm64-v8a.apk">64-bit</a> -
-            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-armeabi-v7a.apk">32-bit</a>
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.11.0/luanti-5.11.0-arm64-v8a.apk">64-bit</a> -
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.11.0/luanti-5.11.0-armeabi-v7a.apk">32-bit</a>
           </li>
           <li>
             x86:
-            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-x86_64.apk">64-bit</a> -
-            <a href="https://github.com/luanti-org/luanti/releases/download/5.10.0/luanti-5.10.0-x86.apk">32-bit</a>
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.11.0/luanti-5.11.0-x86_64.apk">64-bit</a> -
+            <a href="https://github.com/luanti-org/luanti/releases/download/5.11.0/luanti-5.11.0-x86.apk">32-bit</a>
           </li>
-        </ul> -->
+        </ul>
         <p>
           <strong>Note:</strong> We advise not to use unofficial builds commonly found on the Play Store.
           They may contain excessive advertisements or spyware, or be distributed under proprietary terms.


### PR DESCRIPTION
Commit 3: note that Google Play is temporarily unavailable

Commit 2: restore direct APK download links

Commit 1: changes this:

<img alt="screenshot with buttons stuck together vertically" src="https://github.com/user-attachments/assets/8ee1d701-c15c-4624-9b0b-845394f2516c" width="256" />

into this:

<img alt="screenshot with buttons separated vertically" src="https://github.com/user-attachments/assets/bc9df0e9-b646-4be8-ba2f-48f2afbf201a" width="256" />

(on screens where the buttons fit horizontally, this doesn't change anything)

