### PR TITLE
Downloads: reduce getting started section

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -21,7 +21,7 @@ redirect_from:
       guide in our docs. Otherwise, feel free to look at the
       <a href="https://docs.luanti.org/changelog/">changelog</a>.
     </p>
-    
+
     <hr>
     <div class="columns is-multiline">
 

--- a/downloads.html
+++ b/downloads.html
@@ -15,6 +15,14 @@ redirect_from:
   <div class="container content">
 
     <h1>Downloads</h1>
+    <br>
+    <p>
+      Are you a new user? Have a look at the
+      <a href="https://docs.luanti.org/for-players/getting-started/">Getting Started</a>
+      guide in our docs. Otherwise, feel free to look at the
+      <a href="https://docs.luanti.org/changelog/">changelog</a>.
+    </p>
+    
     <hr>
     <div class="columns is-multiline">
 

--- a/downloads.html
+++ b/downloads.html
@@ -15,8 +15,7 @@ redirect_from:
   <div class="container content">
 
     <h1>Downloads</h1>
-    <br>
-    <p>
+    <p class="mt-5">
       Are you a new user? Have a look at the
       <a href="https://docs.luanti.org/for-players/getting-started/">Getting Started</a>
       guide in our docs. Otherwise, feel free to look at the

--- a/downloads.html
+++ b/downloads.html
@@ -15,24 +15,6 @@ redirect_from:
   <div class="container content">
 
     <h1>Downloads</h1>
-    <h2>Getting started</h2>
-    <p>
-      Are you a new user?
-
-      Have a look at our <a href="https://docs.luanti.org/for-players/getting-started/">Getting Started</a>,
-      <a href="https://docs.luanti.org/about/faq/">FAQ</a>,
-       and <a href="https://docs.luanti.org/for-players/">For Players</a> pages on our docs.<br>
-      Otherwise, feel free to look at the <a href="https://docs.luanti.org/changelog/">changelog</a>.
-    </p>
-    <p>
-      You may also want to look at some
-      <a href="https://content.luanti.org/packages/?type=game">games</a>.
-      Games provide basic game play for the engine to run using Lua scripts.
-      Different games have different objectives, such as survival, building or Player vs Player.
-      You can then add <a href="https://content.luanti.org/packages/?type=mod">mods</a> on
-      top of a game in order to customize your experience further.
-    </p>
-
     <hr>
     <div class="columns is-multiline">
 


### PR DESCRIPTION
People clicking on "Downloads" are not looking for guides, tips or changelogs, they're looking for actually downloading Luanti. In general, the [Getting Started page](https://docs.luanti.org/for-players/getting-started/) is quite debatable and the software should explain itself.  

I've kept the `<hr>` because with just one `<br>` looked bad on PC but with two looked bad on mobile.

PC
![image](https://github.com/user-attachments/assets/dab48e8f-548e-4866-89c8-9e34facbd33f)

Mobile
![image](https://github.com/user-attachments/assets/b0755418-f3b4-4331-81a1-3c80cf9203b9)
