### PR TITLE
Downloads: Include brief instructions for running the Windows version

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -42,14 +42,15 @@ redirect_from:
             </a>
           </li>
         </ul>
+        <p>
+          Luanti is distributed as a portable .zip archive on Windows.
+          Extract it to a folder you have write permissions, and run <code>luanti.exe</code>
+          which can be found in the <code>bin</code> folder.
+        </p>
         <ul>
           <li>
               <a href="https://packages.msys2.org/base/mingw-w64-luanti">Luanti MSYS2 package (community-maintained)</a></li>
         </ul>
-        <p>
-          Stuck? See
-          <a href="https://docs.luanti.org/for-players/getting-started/#windows">help on getting Luanti on Windows.</a>
-        </p>
         <p>
           You can also get the latest development version of Luanti from
           <a href="https://forum.luanti.org/viewforum.php?f=42">builds made by community members</a>.


### PR DESCRIPTION
Rather than just dumping the user onto the Getting Started page, include a brief instruction for running the Windows version right below the download links, mentioning most importantly that you need to run `luanti.exe` inside of the `bin` folder.